### PR TITLE
fix split valid issue for kdd ogb-lsc example code

### DIFF
--- a/examples/kddcup2021/MAG240M/r_unimp/split_valid.py
+++ b/examples/kddcup2021/MAG240M/r_unimp/split_valid.py
@@ -1,24 +1,28 @@
 import numpy as np
-from ogb.lsc import MAG240MDataset, MAG240MEvaluator
+from ogb.lsc import MAG240MDataset
+import os
 
-def split_dir(data_dir, output_dit):
-    dataset = MAG240MDataset(data_dir)
+def create_split_dir(source_dir, split_dir):
+    dataset = MAG240MDataset(source_dir)
+    split_dir_exists = os.path.exists(split_dir)
+    if not split_dir_exists:
+        os.mkdir(split_dir)
+
     valid_idx = dataset.get_idx_split("valid")
     np.random.seed(999)
     np.random.shuffle(valid_idx)
-    star = 0
     end = len(valid_idx)
-    part = len(valid_idx)//5 + 1
-    
+    part = len(valid_idx) // 5 + 1
+
     for idx, x in enumerate(range(0, end, part)):
-        y = min(x+part, end)
+        y = min(x + part, end)
         valid_part = valid_idx[x: y]
         print(valid_part.shape)
-        path_p = f"{output_dit}/valid_{idx}"
-        np.save(path_p, valid_part)
+        split_file = f"{split_dir}/valid_{idx}"
+        np.save(split_file, valid_part)
 
 
 if __name__ == "__main__":
-    data_dir = "dataset_path"
-    output_dir = 'valid_64'
-    split_valid(data_dir, output_dir)
+    source_data_dir = 'your_source_data_dir'
+    split_data_dir = 'your_split_data_dir'
+    create_split_dir(source_dir=source_data_dir, split_dir=split_data_dir)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PGL/pull/287 -->
### PR types
[Bug fixes]

### PR changes
[Others]

### Description
when we run split_valid.py to create valid_64 folder, there would throw an error saying the valid file does not exist. This pr tried to fix this issue.
