### PR TITLE
PGL speed up

### DIFF
--- a/apps/GNNAutoScale/README.md
+++ b/apps/GNNAutoScale/README.md
@@ -26,6 +26,7 @@ python run.py --conf config/cora/gcn.yaml
 python run.py --conf config/pubmed/gcn.yaml
 python run.py --conf config/citeseer/gcn.yaml
 python run.py --conf config/reddit/gcn.yaml
+python run.py --conf config/arxiv/gcn.yaml
 
 # GAT
 python run.py --conf config/cora/gat.yaml
@@ -42,6 +43,7 @@ python run.py --conf config/cora/gcnii.yaml
 python run.py --conf config/pubmed/gcnii.yaml
 python run.py --conf config/citeseer/gcnii.yaml
 python run.py --conf config/reddit/gcnii.yaml
+python run.py --conf config/arxiv/gcnii.yaml
 ```
 
 ## Results

--- a/apps/GNNAutoScale/dataset.py
+++ b/apps/GNNAutoScale/dataset.py
@@ -26,6 +26,7 @@ from pgl.utils.logger import log
 from pgl.utils.data import Dataset
 from pgl.sampling.custom import subgraph
 from pgl.utils.data.dataloader import Dataloader
+from pgl.utils.transform import to_undirected, add_self_loops
 
 from utils import generate_mask
 
@@ -193,6 +194,11 @@ def load_dataset(data_name):
         y[dataset.val_index] = dataset.val_label
         y[dataset.test_index] = dataset.test_label
         dataset.y = y
+    elif data_name == 'arxiv':
+        mode = 'm'
+        dataset = pgl.dataset.OgbnArxivDataset()
+        dataset.graph = to_undirected(dataset.graph, copy_node_feat=False)
+        dataset.graph = add_self_loops(dataset.graph, copy_node_feat=False)
     elif data_name == 'cora':
         mode = 's'
         dataset = pgl.dataset.CoraDataset()

--- a/apps/GNNAutoScale/examples/config/arxiv/gcn.yaml
+++ b/apps/GNNAutoScale/examples/config/arxiv/gcn.yaml
@@ -1,0 +1,16 @@
+model_name: GCN
+data_name: arxiv
+num_layers: 3
+num_parts: 80
+batch_size: 40
+hidden_size: 256
+lr: 0.01
+weight_decay: 0.0
+dropout: 0.
+drop_input: False
+batch_norm: False
+gcn_norm: True
+grad_norm: False
+gen_train_data_in_advance: True
+feat_gpu: True
+epochs: 400

--- a/apps/GNNAutoScale/examples/config/arxiv/gcnii.yaml
+++ b/apps/GNNAutoScale/examples/config/arxiv/gcnii.yaml
@@ -1,0 +1,17 @@
+model_name: GCNII
+data_name: arxiv
+num_layers: 4
+num_parts: 40
+batch_size: 20
+hidden_size: 256
+pool_size: 2
+lr: 0.01
+weight_decay: 0.0
+dropout: 0.
+alpha: 0.2
+lambda_l: 0.5
+gcn_norm: True
+grad_norm: False
+gen_train_data_in_advance: True
+feat_gpu: True
+epochs: 500

--- a/pgl/dataset.py
+++ b/pgl/dataset.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This package implements some benchmark dataset for graph network
-and node representation learning.
+    This package implements some benchmark dataset for graph network
+    and node representation learning.
 """
+
 import os
 import io
 import sys
@@ -30,6 +31,7 @@ __all__ = [
     "ArXivDataset",
     "BlogCatalogDataset",
     "RedditDataset",
+    "OgbnArxivDataset",
 ]
 
 
@@ -58,27 +60,30 @@ def _parse_index_file(filename):
 
 
 class CitationDataset(object):
-    """Citation dataset helps to create data for citation dataset (Pubmed and Citeseer)
+    """Citation dataset helps to create data for citation dataset (Pubmed and Citeseer).
 
     Args:
-        name: The name for the dataset ("pubmed" or "citeseer")
 
-        symmetry_edges: Whether to create symmetry edges.
+        name (str): The name for the dataset ("pubmed" or "citeseer").
 
-        self_loop:  Whether to contain self loop edges.
+        symmetry_edges (bool): Whether to create symmetry edges.
+
+        self_loop (bool):  Whether to contain self loop edges.
 
     Attributes:
-        graph: The :code:`Graph` data object
 
-        y: Labels for each nodes
+        graph (pgl.Graph): The :code:`Graph` data object.
 
-        num_classes: Number of classes.
+        y (numpy.ndarray): Labels for each nodes.
 
-        train_index: The index for nodes in training set.
+        num_classes (int): Number of classes.
 
-        val_index: The index for nodes in validation set.
+        train_index (numpy.ndarray): The index for nodes in training set.
 
-        test_index: The index for nodes in test set.
+        val_index (numpy.ndarray): The index for nodes in validation set.
+
+        test_index (numpy.ndarray): The index for nodes in test set.
+
     """
 
     def __init__(self, name, symmetry_edges=True, self_loop=True):
@@ -157,25 +162,28 @@ class CitationDataset(object):
 
 
 class CoraDataset(object):
-    """Cora dataset implementation
+    """Cora dataset implementation.
 
     Args:
-        symmetry_edges: Whether to create symmetry edges.
 
-        self_loop:  Whether to contain self loop edges.
+        symmetry_edges (bool): Whether to create symmetry edges.
+
+        self_loop (bool):  Whether to contain self loop edges.
 
     Attributes:
-        graph: The :code:`Graph` data object
 
-        y: Labels for each nodes
+        graph (pgl.Graph): The :code:`Graph` data object.
 
-        num_classes: Number of classes.
+        y (numpy.ndarray): Labels for each nodes.
 
-        train_index: The index for nodes in training set.
+        num_classes (int): Number of classes.
 
-        val_index: The index for nodes in validation set.
+        train_index (numpy.ndarray): The index for nodes in training set.
 
-        test_index: The index for nodes in test set.
+        val_index (numpy.ndarray): The index for nodes in validation set.
+
+        test_index (numpy.ndarray): The index for nodes in test set.
+
     """
 
     def __init__(self, symmetry_edges=True, self_loop=True):
@@ -239,21 +247,24 @@ class CoraDataset(object):
 
 
 class BlogCatalogDataset(object):
-    """BlogCatalog dataset implementation
+    """BlogCatalog dataset implementation.
 
     Args:
-        symmetry_edges: Whether to create symmetry edges.
 
-        self_loop:  Whether to contain self loop edges.
+        symmetry_edges (bool): Whether to create symmetry edges.
+
+        self_loop (bool):  Whether to contain self loop edges.
 
     Attributes:
-        graph: The :code:`Graph` data object.
 
-        num_groups: Number of classes.
+        graph (pgl.Graph): The :code:`Graph` data object.
 
-        train_index: The index for nodes in training set.
+        num_groups (int): Number of classes.
 
-        test_index: The index for nodes in validation set.
+        train_index (numpy.ndarray): The index for nodes in training set.
+
+        test_index (numpy.ndarray): The index for nodes in validation set.
+
     """
 
     def __init__(self, symmetry_edges=True, self_loop=False):
@@ -307,13 +318,16 @@ class BlogCatalogDataset(object):
 
 
 class ArXivDataset(object):
-    """ArXiv dataset implementation
+    """ArXiv dataset implementation.
 
     Args:
-        np_random_seed: The random seed for numpy.
+
+        np_random_seed (int): The random seed for numpy.
 
     Attributes:
-        graph: The :code:`Graph` data object.
+
+        graph (pgl.Graph): The :code:`Graph` data object.
+
     """
 
     def __init__(self, np_random_seed=123):
@@ -370,6 +384,36 @@ class ArXivDataset(object):
 
 
 class RedditDataset(object):
+    """Reddit dataset implementation.
+
+    Args:
+
+        normalize (bool): Whether to normalize feature.
+
+        symmetry (bool): Whether to create symmetry edges.
+
+    Attributes:
+
+        graph (pgl.Graph): The :code:`Graph` data object.
+
+        feature (numpy.ndarray): The feature of nodes.
+
+        num_classes (int): Number of classes.
+
+        train_index (numpy.ndarray): The index for nodes in training set.
+
+        val_index (numpy.ndarray): The index for nodes in validation set.
+
+        test_index (numpy.ndarray): The index for nodes in test set.
+
+        train_label (numpy.ndarray): The label for nodes in training set.
+
+        val_label (numpy.ndarray): The label for nodes in validation set.
+
+        test_label (numpy.ndarray): The label for nodes in test set.
+
+    """
+
     def __init__(self, normalize=True, symmetry=True):
         download_help_str = r"""
             data from https://github.com/matenure/FastGCN/issues/8
@@ -427,3 +471,53 @@ class RedditDataset(object):
         self.test_label = test_label
         self.feature = feature
         self.num_classes = 41
+
+
+class OgbnArxivDataset(object):
+    """Ogbn Arxiv Dataset import and implementation.
+
+    Attributes:
+
+        graph (pgl.Graph): The :code:`Graph` data object.
+
+        feature (numpy.ndarray): The feature of all nodes.
+
+        y (numpy.ndarray): Labels for each nodes.
+
+        num_classes (int): Number of classes.
+
+        train_index (numpy.ndarray): The index for nodes in training set.
+
+        val_index (numpy.ndarray): The index for nodes in validation set.
+
+        test_index (numpy.ndarray): The index for nodes in test set.
+
+    """
+
+    def __init__(self):
+        try:
+            from ogb.nodeproppred import NodePropPredDataset
+        except:
+            raise ImportError(
+                "Please run `pip install ogb` to install ogb library.")
+
+        self.dataset = NodePropPredDataset(name="ogbn-arxiv")
+        self._load_data()
+
+    def _load_data(self):
+        split_idx = self.dataset.get_idx_split()
+        train_idx = split_idx["train"]
+        valid_idx = split_idx["valid"]
+        test_idx = split_idx["test"]
+        ogb_graph, label = self.dataset[0]
+
+        edges = ogb_graph["edge_index"].T
+        graph = Graph(num_nodes=ogb_graph["num_nodes"], edges=edges)
+
+        self.graph = graph
+        self.feature = ogb_graph["node_feat"]
+        self.y = label
+        self.num_classes = self.dataset.num_classes
+        self.train_index = train_idx
+        self.val_index = valid_idx
+        self.test_index = test_idx

--- a/pgl/graph.py
+++ b/pgl/graph.py
@@ -17,19 +17,21 @@
 
 import os
 import json
-import paddle
 import copy
+import warnings
+from collections import defaultdict
+
 import numpy as np
+import paddle
+import paddle.distributed as dist
+from paddle.framework import core
 
 from pgl.utils import op
 import pgl.graph_kernel as graph_kernel
-
 from pgl.message import Message
-from collections import defaultdict
-from pgl.utils.helper import check_is_tensor, scatter, generate_segment_id_from_index, maybe_num_nodes, unique_segment
 from pgl.utils.edge_index import EdgeIndex
-import paddle.distributed as dist
-import warnings
+from pgl.utils.helper import check_is_tensor, scatter, maybe_num_nodes
+from pgl.utils.helper import generate_segment_id_from_index, unique_segment
 
 
 class Graph(object):
@@ -137,12 +139,6 @@ class Graph(object):
             self._num_nodes = maybe_num_nodes(self._edges)
         else:
             self._num_nodes = num_nodes
-            max_edge_id = maybe_num_nodes(self._edges)
-            if not isinstance(max_edge_id, paddle.fluid.framework.
-                              Variable) and self._num_nodes < max_edge_id:
-                raise ValueError("The max edge ID should be less than the number of nodes. "
-                        "But got max edge ID [%s] >= num_nodes [%s]" \
-                        % (max_edge_id-1, self._num_nodes))
 
         self._adj_src_index = kwargs.get("adj_src_index", None)
         self._adj_dst_index = kwargs.get("adj_dst_index", None)

--- a/pgl/nn/conv.py
+++ b/pgl/nn/conv.py
@@ -14,6 +14,7 @@
 """This package implements common layers to help building
 graph neural networks.
 """
+
 import numpy as np
 import paddle
 import paddle.nn as nn

--- a/tests/test_bigraph.py
+++ b/tests/test_bigraph.py
@@ -23,25 +23,6 @@ from testsuite import create_random_bigraph
 
 
 class BiGraphTest(unittest.TestCase):
-    def test_num_nodes_valid(self):
-        src_num_nodes = 1
-        dst_num_nodes = 5
-        dim = 4
-        edges = [(0, 1), (1, 2), (3, 4)]
-        src_nfeat = np.random.randn(src_num_nodes, dim)
-        dst_nfeat = np.random.randn(dst_num_nodes, dim)
-        efeat = np.random.randn(len(edges), dim)
-        
-        with self.assertRaises(ValueError):
-            g1 = pgl.BiGraph(
-                edges=edges,
-                src_num_nodes=src_num_nodes,
-                dst_num_nodes=dst_num_nodes,
-                src_node_feat={'src_nfeat': src_nfeat},
-                dst_node_feat={'dst_nfeat': dst_nfeat},
-                edge_feat={'efeat': efeat})
-
-
     def test_check_to_tensor_to_numpy(self):
 
         src_num_nodes = 4
@@ -51,7 +32,7 @@ class BiGraphTest(unittest.TestCase):
         src_nfeat = np.random.randn(src_num_nodes, dim)
         dst_nfeat = np.random.randn(dst_num_nodes, dim)
         efeat = np.random.randn(len(edges), dim)
-        
+
         g1 = pgl.BiGraph(
             edges=edges,
             src_num_nodes=src_num_nodes,
@@ -61,16 +42,16 @@ class BiGraphTest(unittest.TestCase):
             edge_feat={'efeat': efeat})
         # check inplace to tensor
         self.assertFalse(g1.is_tensor())
-        
+
         g2 = g1.tensor(inplace=False)
         g3 = g2.numpy(inplace=False)
-        
+
         self.assertFalse(g1.is_tensor())
         self.assertTrue(g2.is_tensor())
         self.assertFalse(g3.is_tensor())
 
     def test_build_graph(self):
-    
+
         src_num_nodes = 4
         dst_num_nodes = 5
         dim = 4
@@ -78,7 +59,7 @@ class BiGraphTest(unittest.TestCase):
         src_nfeat = np.random.randn(src_num_nodes, dim)
         dst_nfeat = np.random.randn(dst_num_nodes, dim)
         efeat = np.random.randn(len(edges), dim)
-        
+
         g1 = pgl.BiGraph(
             edges=edges,
             src_num_nodes=src_num_nodes,
@@ -86,7 +67,6 @@ class BiGraphTest(unittest.TestCase):
             src_node_feat={'src_nfeat': src_nfeat},
             dst_node_feat={'dst_nfeat': dst_nfeat},
             edge_feat={'efeat': efeat})
- 
 
     def test_build_tensor_graph(self):
         src_num_nodes = paddle.to_tensor(4)
@@ -94,8 +74,10 @@ class BiGraphTest(unittest.TestCase):
         e = np.array([(0, 1), (1, 2), (3, 4)])
         edges = paddle.to_tensor(e)
 
-        g2 = pgl.BiGraph(edges=edges, src_num_nodes=src_num_nodes,
-                    dst_num_nodes=dst_num_nodes)
+        g2 = pgl.BiGraph(
+            edges=edges,
+            src_num_nodes=src_num_nodes,
+            dst_num_nodes=dst_num_nodes)
 
     def test_build_graph_without_num_nodes(self):
         e = np.array([(0, 1), (1, 2), (3, 4)])
@@ -109,7 +91,10 @@ class BiGraphTest(unittest.TestCase):
         src_num_nodes = 4
         dst_num_nodes = 5
         edges = [(0, 1), (1, 2), (3, 4)]
-        g1 = pgl.BiGraph(edges=edges, src_num_nodes=src_num_nodes, dst_num_nodes=dst_num_nodes)
+        g1 = pgl.BiGraph(
+            edges=edges,
+            src_num_nodes=src_num_nodes,
+            dst_num_nodes=dst_num_nodes)
         indegree = np.array([0, 1, 1, 0, 1], dtype="int32")
         outdegree = np.array([1, 1, 0, 1], dtype="int32")
         # check degree in numpy
@@ -154,14 +139,10 @@ class BiGraphTest(unittest.TestCase):
             dst_num_nodes = np.random.randint(low=2, high=10)
             edges_size = np.random.randint(low=1, high=10)
             edges_src = np.random.randint(
-                low=1,
-                high=src_num_nodes,
-                size=[edges_size, 1])
+                low=1, high=src_num_nodes, size=[edges_size, 1])
 
             edges_dst = np.random.randint(
-                low=1,
-                high=dst_num_nodes,
-                size=[edges_size, 1])
+                low=1, high=dst_num_nodes, size=[edges_size, 1])
 
             edges = np.hstack([edges_src, edges_dst])
 
@@ -181,14 +162,20 @@ class BiGraphTest(unittest.TestCase):
         b_graph = pgl.BiGraph.batch(glist)
         multi_graph = pgl.BiGraph.disjoint(glist)
         # Check Graph Index
-        src_node_index = [np.ones(g.src_num_nodes) * n for n, g in enumerate(glist)]
-        dst_node_index = [np.ones(g.dst_num_nodes) * n for n, g in enumerate(glist)]
+        src_node_index = [
+            np.ones(g.src_num_nodes) * n for n, g in enumerate(glist)
+        ]
+        dst_node_index = [
+            np.ones(g.dst_num_nodes) * n for n, g in enumerate(glist)
+        ]
         edge_index = [np.ones(g.num_edges) * n for n, g in enumerate(glist)]
         src_node_index = np.concatenate(src_node_index)
         dst_node_index = np.concatenate(dst_node_index)
         edge_index = np.concatenate(edge_index)
-        self.assertTrue(np.all(src_node_index == multi_graph.graph_src_node_id))
-        self.assertTrue(np.all(dst_node_index == multi_graph.graph_dst_node_id))
+        self.assertTrue(
+            np.all(src_node_index == multi_graph.graph_src_node_id))
+        self.assertTrue(
+            np.all(dst_node_index == multi_graph.graph_dst_node_id))
         self.assertTrue(np.all(edge_index == multi_graph.graph_edge_id))
 
         multi_graph.tensor()
@@ -215,14 +202,10 @@ class BiGraphTest(unittest.TestCase):
             dst_num_nodes = np.random.randint(low=2, high=10)
             edges_size = np.random.randint(low=1, high=10)
             edges_src = np.random.randint(
-                low=1,
-                high=src_num_nodes,
-                size=[edges_size, 1])
+                low=1, high=src_num_nodes, size=[edges_size, 1])
 
             edges_dst = np.random.randint(
-                low=1,
-                high=dst_num_nodes,
-                size=[edges_size, 1])
+                low=1, high=dst_num_nodes, size=[edges_size, 1])
 
             edges = np.hstack([edges_src, edges_dst])
 
@@ -241,15 +224,22 @@ class BiGraphTest(unittest.TestCase):
         # Merge Graph
         multi_graph = pgl.BiGraph.disjoint(glist)
         # Check Graph Index
-        src_node_index = [np.ones(g.src_num_nodes) * n for n, g in enumerate(glist)]
-        dst_node_index = [np.ones(g.dst_num_nodes) * n for n, g in enumerate(glist)]
+        src_node_index = [
+            np.ones(g.src_num_nodes) * n for n, g in enumerate(glist)
+        ]
+        dst_node_index = [
+            np.ones(g.dst_num_nodes) * n for n, g in enumerate(glist)
+        ]
         edge_index = [np.ones(g.num_edges) * n for n, g in enumerate(glist)]
         src_node_index = np.concatenate(src_node_index)
         dst_node_index = np.concatenate(dst_node_index)
         edge_index = np.concatenate(edge_index)
-        self.assertTrue(np.all(src_node_index == multi_graph.graph_src_node_id.numpy()))
-        self.assertTrue(np.all(dst_node_index == multi_graph.graph_dst_node_id.numpy()))
-        self.assertTrue(np.all(edge_index == multi_graph.graph_edge_id.numpy()))
+        self.assertTrue(
+            np.all(src_node_index == multi_graph.graph_src_node_id.numpy()))
+        self.assertTrue(
+            np.all(dst_node_index == multi_graph.graph_dst_node_id.numpy()))
+        self.assertTrue(
+            np.all(edge_index == multi_graph.graph_edge_id.numpy()))
 
         multi_graph.tensor()
         self.assertTrue(
@@ -265,7 +255,6 @@ class BiGraphTest(unittest.TestCase):
         self.assertEqual(multi_graph.dst_node_feat['nfeat'].shape,
                          [glist[0].dst_num_nodes.numpy()[0], dim])
 
-
     def test_dump_numpy_load_numpy(self):
 
         path = './tmp'
@@ -274,14 +263,10 @@ class BiGraphTest(unittest.TestCase):
         dst_num_nodes = np.random.randint(low=2, high=10)
         edges_size = np.random.randint(low=1, high=10)
         edges_src = np.random.randint(
-            low=1,
-            high=src_num_nodes,
-            size=[edges_size, 1])
+            low=1, high=src_num_nodes, size=[edges_size, 1])
 
         edges_dst = np.random.randint(
-            low=1,
-            high=dst_num_nodes,
-            size=[edges_size, 1])
+            low=1, high=dst_num_nodes, size=[edges_size, 1])
 
         edges = np.hstack([edges_src, edges_dst])
 
@@ -318,14 +303,10 @@ class BiGraphTest(unittest.TestCase):
         dst_num_nodes = np.random.randint(low=2, high=10)
         edges_size = np.random.randint(low=1, high=10)
         edges_src = np.random.randint(
-            low=1,
-            high=src_num_nodes,
-            size=[edges_size, 1])
+            low=1, high=src_num_nodes, size=[edges_size, 1])
 
         edges_dst = np.random.randint(
-            low=1,
-            high=dst_num_nodes,
-            size=[edges_size, 1])
+            low=1, high=dst_num_nodes, size=[edges_size, 1])
 
         edges = np.hstack([edges_src, edges_dst])
 
@@ -340,7 +321,7 @@ class BiGraphTest(unittest.TestCase):
             src_node_feat={'nfeat': paddle.to_tensor(src_nfeat)},
             dst_node_feat={'nfeat': paddle.to_tensor(dst_nfeat)},
             edge_feat={'efeat': paddle.to_tensor(efeat)})
-       
+
         in_before = g.indegree()
         g.outdegree()
         g.tensor()
@@ -365,7 +346,7 @@ class BiGraphTest(unittest.TestCase):
         src_nfeat = np.arange(src_num_nodes).reshape(-1, 1)
         dst_nfeat = np.arange(dst_num_nodes).reshape(-1, 1)
         efeat = np.arange(len(edges)).reshape(-1, 1)
-        
+
         g1 = pgl.BiGraph(
             edges=edges,
             src_num_nodes=src_num_nodes,
@@ -409,11 +390,11 @@ class BiGraphTest(unittest.TestCase):
     def test_send_recv_func(self):
 
         np.random.seed(0)
-        src_num_nodes = 5 
+        src_num_nodes = 5
         dst_num_nodes = 4
         edges = [(0, 1), (1, 2), (3, 3), (4, 1), (1, 0)]
         src_nfeat = np.array([[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6],
-                          [4, 5, 6, 7], [5, 6, 7, 8]])
+                              [4, 5, 6, 7], [5, 6, 7, 8]])
 
         ground = np.array([[2, 3, 4, 5], [6, 8, 10, 12], [2, 3, 4, 5],
                            [4, 5, 6, 7]])
@@ -422,8 +403,7 @@ class BiGraphTest(unittest.TestCase):
             edges=edges,
             src_num_nodes=src_num_nodes,
             dst_num_nodes=dst_num_nodes,
-            src_node_feat={'src_nfeat': src_nfeat},
-            )
+            src_node_feat={'src_nfeat': src_nfeat}, )
         g.tensor()
 
         output = g.send_recv(g.src_node_feat['src_nfeat'], reduce_func="sum")
@@ -433,14 +413,17 @@ class BiGraphTest(unittest.TestCase):
 
     def test_send_and_recv(self):
         np.random.seed(0)
-        src_num_nodes = 5 
+        src_num_nodes = 5
         dst_num_nodes = 4
         edges = [(0, 1), (1, 2), (3, 3), (4, 1), (1, 0)]
-        src_nfeat = np.array([[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6],
-                          [4, 5, 6, 7], [5, 6, 7, 8]], dtype="float32")
+        src_nfeat = np.array(
+            [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6], [4, 5, 6, 7],
+             [5, 6, 7, 8]],
+            dtype="float32")
 
-        dst_nfeat = np.array([[2, 3, 4, 5], [3, 4, 5, 6],
-                          [4, 5, 6, 7], [5, 6, 7, 8]], dtype="float32")
+        dst_nfeat = np.array(
+            [[2, 3, 4, 5], [3, 4, 5, 6], [4, 5, 6, 7], [5, 6, 7, 8]],
+            dtype="float32")
 
         src_ground = np.array(
             [[1, 2, 3, 4], [2, 3, 4, 5], [4, 5, 6, 7], [5, 6, 7, 8],
@@ -448,7 +431,7 @@ class BiGraphTest(unittest.TestCase):
             dtype="float32")
 
         src_recv = np.array([[2, 3, 4, 5], [6, 8, 10, 12], [2, 3, 4, 5],
-                           [4, 5, 6, 7]])
+                             [4, 5, 6, 7]])
 
         dst_ground = np.array(
             [[3, 4, 5, 6], [4, 5, 6, 7], [5, 6, 7, 8], [3, 4, 5, 6],
@@ -456,15 +439,14 @@ class BiGraphTest(unittest.TestCase):
             dtype="float32")
 
         dst_recv = np.array([[3, 4, 5, 6], [6, 8, 10, 12], [0, 0, 0, 0],
-                           [5, 6, 7, 8], [3, 4, 5, 6]])
+                             [5, 6, 7, 8], [3, 4, 5, 6]])
 
         g = pgl.BiGraph(
             edges=edges,
             src_num_nodes=src_num_nodes,
             dst_num_nodes=dst_num_nodes,
             src_node_feat={'src_nfeat': src_nfeat},
-            dst_node_feat={'dst_nfeat': dst_nfeat}
-            )
+            dst_node_feat={'dst_nfeat': dst_nfeat})
 
         g.tensor()
 
@@ -505,7 +487,8 @@ class BiGraphTest(unittest.TestCase):
             return msg.reduce_sum(msg['h'])
 
         # test send_func1
-        msg1 = g.send(send_func1_d, dst_feat={'h': g.dst_node_feat['dst_nfeat']})
+        msg1 = g.send(
+            send_func1_d, dst_feat={'h': g.dst_node_feat['dst_nfeat']})
         _msg = msg1['h'].numpy()
         self.assertTrue((dst_ground == _msg).all())
 
@@ -514,14 +497,14 @@ class BiGraphTest(unittest.TestCase):
         self.assertTrue((dst_recv == output).all())
 
         # test send_func2
-        msg2 = g.send(send_func2_d, dst_feat={'h': g.dst_node_feat['dst_nfeat']})
+        msg2 = g.send(
+            send_func2_d, dst_feat={'h': g.dst_node_feat['dst_nfeat']})
         _msg = msg2['h'].numpy()
         self.assertTrue((dst_ground == _msg).all())
 
         output = g.recv(reduce_func_d, msg2, recv_mode="src")
         output = output.numpy()
         self.assertTrue((dst_recv == output).all())
-
 
     def test_node_iter(self):
         np_graph = create_random_bigraph().numpy()
@@ -533,7 +516,7 @@ class BiGraphTest(unittest.TestCase):
             for shuffle in [True, False]:
                 for m in ["src_node", "dst_node"]:
                     for batch_data in graph.node_batch_iter(
-                        batch_size=3, shuffle=shuffle, mode=m):
+                            batch_size=3, shuffle=shuffle, mode=m):
                         break
 
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -59,21 +59,6 @@ class GraphTest(unittest.TestCase):
             node_feat={'nfeat': nfeat},
             edge_feat={'efeat': efeat})
 
-    def test_num_nodes_valid(self):
-
-        num_nodes = 3
-        dim = 4
-        edges = [(0, 1), (1, 2), (3, 4)]
-        nfeat = np.random.randn(num_nodes, dim)
-        efeat = np.random.randn(len(edges), dim)
-
-        with self.assertRaises(ValueError):
-            g1 = pgl.Graph(
-                edges=edges,
-                num_nodes=num_nodes,
-                node_feat={'nfeat': nfeat},
-                edge_feat={'efeat': efeat})
-
     def test_build_tensor_graph(self):
         num_nodes = paddle.to_tensor(5)
         e = np.array([(0, 1), (1, 2), (3, 4)])


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Framework, Models

### Description
1. Delete maybe_num_nodes and corresponding unittests.
2. Add ogbn-arxiv dataset and GNNAutoScale arxiv support.
3. Update graph.send_recv function for compatibility, and move original send_recv to pgl.utils.helper.
4. Change send_recv function of GraphSageConv, PinSageConv, RGCNConv. (NOT Commited yet, needed ensurement.)
    **After discussion, GraphSageConv, etc. do not need to be changed temporarily.**
5. Update Dataset and Dataloader of GNNAutoScale for performance optimization. (NOT Commited yet, needed ensurement.)

### Model update - temporarily finished

- [x] GCNConv
- [ ] GATConv
- [x] APPNP
- [x] GCNII
- [ ] TransformerConv
- [x] GINConv
- [ ] GraphSageConv
- [ ] PinSageConv
- [ ] RGCNConv
- [x] SGCConv
- [x] SSGCConv
- [x] NGCFConv
- [x] LightGCNConv