### PR TITLE
Fix multiprocessing context error

### DIFF
--- a/pgl/utils/mp_reader.py
+++ b/pgl/utils/mp_reader.py
@@ -16,7 +16,10 @@
 import logging
 log = logging.getLogger(__name__)
 import multiprocessing
-multiprocessing.set_start_method('fork', force=True)
+try:
+    multiprocessing.set_start_method('fork')
+except RuntimeError:
+    pass
 log.info("We set multiprocessing start method as 'fork' by default.")
 import copy
 try:

--- a/pgl/utils/mp_reader.py
+++ b/pgl/utils/mp_reader.py
@@ -16,7 +16,7 @@
 import logging
 log = logging.getLogger(__name__)
 import multiprocessing
-multiprocessing.set_start_method('fork')
+multiprocessing.set_start_method('fork', force=True)
 log.info("We set multiprocessing start method as 'fork' by default.")
 import copy
 try:

--- a/pgl/utils/mp_reader.py
+++ b/pgl/utils/mp_reader.py
@@ -13,14 +13,10 @@
 # limitations under the License.
 """Optimized Multiprocessing Reader for PaddlePaddle
 """
+
 import logging
 log = logging.getLogger(__name__)
 import multiprocessing
-try:
-    multiprocessing.set_start_method('fork')
-except RuntimeError:
-    pass
-log.info("We set multiprocessing start method as 'fork' by default.")
 import copy
 try:
     import ujson as json
@@ -123,7 +119,13 @@ def multiprocess_reader(readers, use_pipe=True, queue_size=1000, pipe_size=10):
             queues.append(queue)
             p = multiprocessing.Process(
                 target=_read_into_queue, args=(reader, queue))
-            p.start()
+            try:
+                p.start()
+            except:
+                raise RuntimeError(
+                    f"The program met some problems. If you system is Mac OS and python >= 3.8, "
+                    f"please checkout https://github.com/PaddlePaddle/PGL/issues/305 to fix the problem."
+                )
 
         reader_num = len(readers)
         alive_queue_indices = [i for i in range(reader_num)]
@@ -152,7 +154,13 @@ def multiprocess_reader(readers, use_pipe=True, queue_size=1000, pipe_size=10):
             conns.append(parent_conn)
             p = multiprocessing.Process(
                 target=_read_into_pipe, args=(reader, child_conn, pipe_size))
-            p.start()
+            try:
+                p.start()
+            except:
+                raise RuntimeError(
+                    f"The program met some problems. If you system is Mac OS and python >= 3.8, "
+                    f"please checkout https://github.com/PaddlePaddle/PGL/issues/305 to fix the problem."
+                )
 
         reader_num = len(readers)
         conn_to_remove = []

--- a/pgl/utils/mp_reader.py
+++ b/pgl/utils/mp_reader.py
@@ -123,7 +123,7 @@ def multiprocess_reader(readers, use_pipe=True, queue_size=1000, pipe_size=10):
                 p.start()
             except:
                 raise RuntimeError(
-                    f"The program met some problems. If you system is Mac OS and python >= 3.8, "
+                    f"The program met some problems. If your system is Mac OS and python >= 3.8, "
                     f"please checkout https://github.com/PaddlePaddle/PGL/issues/305 to fix the problem."
                 )
 
@@ -158,7 +158,7 @@ def multiprocess_reader(readers, use_pipe=True, queue_size=1000, pipe_size=10):
                 p.start()
             except:
                 raise RuntimeError(
-                    f"The program met some problems. If you system is Mac OS and python >= 3.8, "
+                    f"The program met some problems. If your system is Mac OS and python >= 3.8, "
                     f"please checkout https://github.com/PaddlePaddle/PGL/issues/305 to fix the problem."
                 )
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PGL/pull/287 -->
### PR types
Bug fixes

### PR changes
Others

### Description
修复问题：https://github.com/PaddlePaddle/PGL/issues/355

问题描述：许多的python package都可能用到python的multiprocessing，因此彼此之间会产生冲突。例如，我们在 pgl.utils.mp_reader 当中设置了multiprocessing.set_start_method('fork')，如果有同学在这之前或之后也设置相同操作，就会出现context has already been set的问题。

两种临时解决方法：
1. multiprocessing.set_start_method('fork', force=True) ，但这种方式据说会造成信号量泄露；
2. 另一种写法通过 try except 来完成。

这里我们选择第二种方式。注意，如果同学在这之后采用multiprocessing.set_start_method('fork')，仍然会出现context has already been set的问题，这时候需要自己采用上述两种方法解决。
