### PR TITLE
[BugFix] fix in_dygraph_mode api changes

### DIFF
--- a/pgl/math.py
+++ b/pgl/math.py
@@ -23,8 +23,13 @@ __all__ = [
 ]
 
 import paddle
-from paddle.fluid.framework import core, in_dygraph_mode
-from paddle.fluid.layer_helper import LayerHelper, in_dygraph_mode
+from paddle.fluid.framework import core
+from paddle.fluid.layer_helper import LayerHelper
+try:
+    from paddle.fluid.layer_helper import in_dygraph_mode as non_static_mode
+except ImportError:
+    from paddle.fluid.layer_helper import _non_static_mode as non_static_mode
+
 from paddle.fluid.data_feeder import check_variable_and_dtype
 from pgl.utils.op import get_index_from_counts
 
@@ -34,7 +39,7 @@ def segment_pool(data, segment_ids, pool_type, name=None):
     Segment Operator.
     """
     pool_type = pool_type.upper()
-    if in_dygraph_mode():
+    if non_static_mode():
         out, tmp = core.ops.segment_pool(data, segment_ids, 'pooltype',
                                          pool_type)
         return out
@@ -89,7 +94,7 @@ def segment_sum(data, segment_ids, name=None):
     if paddle.__version__ >= '2.2.0':
         return paddle.incubate.segment_sum(data, segment_ids, name)
 
-    if in_dygraph_mode():
+    if non_static_mode():
         out, tmp = core.ops.segment_pool(data, segment_ids, 'pooltype', "SUM")
         return out
 
@@ -144,7 +149,7 @@ def segment_mean(data, segment_ids, name=None):
     if paddle.__version__ >= '2.2.0':
         return paddle.incubate.segment_mean(data, segment_ids, name)
 
-    if in_dygraph_mode():
+    if non_static_mode():
         out, tmp = core.ops.segment_pool(data, segment_ids, 'pooltype', "MEAN")
         return out
 
@@ -197,7 +202,7 @@ def segment_min(data, segment_ids, name=None):
     if paddle.__version__ >= '2.2.0':
         return paddle.incubate.segment_min(data, segment_ids, name)
 
-    if in_dygraph_mode():
+    if non_static_mode():
         out, tmp = core.ops.segment_pool(data, segment_ids, 'pooltype', "MIN")
         return out
 
@@ -251,7 +256,7 @@ def segment_max(data, segment_ids, name=None):
     if paddle.__version__ >= '2.2.0':
         return paddle.incubate.segment_max(data, segment_ids, name)
 
-    if in_dygraph_mode():
+    if non_static_mode():
         out, tmp = core.ops.segment_pool(data, segment_ids, 'pooltype', "MAX")
         return out
 

--- a/pgl/utils/helper.py
+++ b/pgl/utils/helper.py
@@ -17,9 +17,14 @@ import paddle
 from paddle.fluid.layers import core
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.data_feeder import convert_dtype, check_variable_and_dtype, check_type, check_dtype
-from paddle.fluid.framework import Variable, in_dygraph_mode, convert_np_dtype_to_dtype_
-import paddle.fluid.layers as L
+from paddle.fluid.framework import Variable, convert_np_dtype_to_dtype_
 
+try:
+    from paddle.fluid.layer_helper import in_dygraph_mode as non_static_mode
+except ImportError:
+    from paddle.fluid.layer_helper import _non_static_mode as non_static_mode
+
+import paddle.fluid.layers as L
 from pgl.utils import op
 
 
@@ -99,7 +104,7 @@ def scatter(x, index, updates, overwrite=True, name=None):
             #  [2., 2.],
             #  [1., 1.]]
     """
-    if in_dygraph_mode():
+    if non_static_mode():
         return core.ops.scatter(x, index, updates, 'overwrite', overwrite)
 
     check_variable_and_dtype(
@@ -160,7 +165,7 @@ def maybe_num_nodes(edges):
 def unique_segment(data, dtype="int64"):
     """Return Segment Id from data
     """
-    if in_dygraph_mode():
+    if non_static_mode():
         attr_dtype = convert_np_dtype_to_dtype_(dtype)
         unique, index, _ = core.ops.unique_with_counts(data, "dtype",
                                                        attr_dtype)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PGL/pull/287 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others  ] -->
Bug fixes
### PR changes
<!-- One of [ Framework | Models | APIs | Docs | Others  ] -->
Others
### Description
<!-- Describe what this PR does -->

<img width="1378" alt="109608a58306a7edd82a1b03551ff8bd" src="https://user-images.githubusercontent.com/16911935/160327925-baa5f764-2566-431d-85c2-0de93aaabccc.png">

https://github.com/PaddlePaddle/Paddle/pull/40786
in dygraph api changes
> 简单来说是将执行机制在python分成static和non_static通过_non_static_mode来判断，这里_non_static_mode等同于从前in_dygraph_mode的功能。而在_non_static_mode下区分是否是_in_legacy_dygraph如果是则运行老动态图，否则运行新动态图